### PR TITLE
sontek

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ function link_file {
     source="${PWD}/$1"
     target="${HOME}/${1/_/.}"
 
-    if [ -e "${target}" ]; then
+    if [ -e "${target}" ] && [ ! -L "${target}" ]; then
         mv $target $target.bak
     fi
 


### PR DESCRIPTION
Here's a fix to the install script that makes sure that you don't overwrite the .bak files with a symbolic link.  If the file exists and is a symbolic link already, it won't hurt as much to overwrite it because it exists elsewhere in the filesystem.

Thanks for such a great dotfiles.  I love what it's done to my pythoning.

-ClashTheBunny
