### PR TITLE
Fixe parse_git_branch to retrieve the current git branch.

### DIFF
--- a/_bashrc
+++ b/_bashrc
@@ -155,7 +155,7 @@ export PYTHONSTARTUP
 
 parse_git_branch ()
 {
-  git name-rev HEAD 2> /dev/null | sed 's#HEAD\ \(.*\)#(git::\1)#'
+  git branch 2> /dev/null | grep '*' | sed 's#*\ \(.*\)#(git::\1)#'
 }
 parse_svn_branch() {
   parse_svn_url | sed -e 's#^'"$(parse_svn_repository_root)"'##g' | awk -F / '{print "(svn::"$1 "/" $2 ")"}'


### PR DESCRIPTION
Fixe parse_git_branch to retrieve the current git branch.

git rev-name may give another branch that the current branch.
