### PR TITLE
feat: add AOE dev image and Colima per-project dev VMs

### DIFF
--- a/aoe/Dockerfile
+++ b/aoe/Dockerfile
@@ -1,0 +1,143 @@
+# Slim, Claude-only developer-machine image for Agent of Empires sandboxes.
+#
+# WHY NOT `FROM aoe-sandbox`: the AOE base bundles ~12 agent CLIs (Hermes alone is
+# 2.85GB) plus a Rust/bun toolchain — ~8.7GB before we add anything, and you can't
+# `rm` it back out (union FS keeps the parent's bytes). This image instead starts
+# from clean Ubuntu and reproduces ONLY the Claude pieces AOE needs, cutting ~7GB.
+#
+# AOE execs the agent by bare binary name (src/cockpit/agent_registry.rs):
+#   tmux mode    -> `claude`             (Claude Code CLI)
+#   cockpit/ACP  -> `claude-agent-acp`   (Zed adapter, npm @agentclientprotocol/...)
+# Both are installed below. SELECTING ANY OTHER AGENT IN AOE WILL FAIL in this
+# image — that's the deliberate trade for the size cut. The ACP adapter is pinned
+# to the major AOE's cockpit expects; rebuild when AOE bumps it.
+#
+# AOE overrides the entrypoint to `sleep infinity` and runs everything via
+# `docker exec` (no guaranteed login shell), so tool PATH comes from ENV/profile.d
+# below, not a login shell. Pin a digest in production.
+FROM ubuntu:26.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+# --- One apt layer: base OS tooling + build deps + docker CLI + psql + the
+# Chromium runtime libs Playwright needs (the 26.04 t64 set, verified via ldd).
+# docker.io/docker-compose-v2 give the CLI only; it drives the host daemon over
+# the mounted socket (see config.example.toml). Acquire::Retries rides out the
+# occasional archive.ubuntu.com index hiccup.
+RUN apt-get update -o Acquire::Retries=3 && apt-get install -y --no-install-recommends \
+      ca-certificates curl git gnupg unzip xz-utils \
+      build-essential pkg-config libssl-dev zlib1g-dev \
+      jq fzf ripgrep openssh-client tmux \
+      postgresql-client docker.io docker-compose-v2 \
+      libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libxkbcommon0 \
+      libasound2t64 libatk1.0-0t64 libatk-bridge2.0-0t64 libatspi2.0-0t64 \
+      libcairo2 libcups2t64 libdbus-1-3 libgbm1 libglib2.0-0t64 \
+      libnspr4 libnss3 libpango-1.0-0 \
+ && rm -rf /var/lib/apt/lists/*
+
+# --- Node (system): the Claude ACP adapter + the npx-driven diagram skills run on
+# it. nodesource 22, matching what aoe-sandbox shipped; mise node@24 layers on top
+# for project work (mise shims take PATH precedence; the adapter still resolves).
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+# --- Claude: CLI (`claude`, standalone binary) + ACP adapter (`claude-agent-acp`).
+# IS_SANDBOX=1 lets Claude Code use --dangerously-skip-permissions as root, and
+# the dirs are where AOE seeds mounted credentials.
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/root/.local/bin:${PATH}"
+RUN npm install -g @agentclientprotocol/claude-agent-acp@^0.39.0 \
+ && mkdir -p /root/.claude /root/.ssh
+ENV IS_SANDBOX=1
+
+# --- Git: rewrite GitHub SSH remotes -> HTTPS so AOE's GH_TOKEN credential helper
+# authenticates push/pull without an SSH key in the sandbox. System-level
+# (/etc/gitconfig) so it applies to BOTH Claude's git (which uses
+# GIT_CONFIG_GLOBAL=~/.sandbox-gitconfig) and plain terminal git; the system file
+# is always read regardless of GIT_CONFIG_GLOBAL, and layers with AOE's seeded
+# token helper. Forward the token via `[sandbox] environment = ["GH_TOKEN"]`.
+RUN git config --system url."https://github.com/".insteadOf "git@github.com:" \
+ && git config --system --add url."https://github.com/".insteadOf "ssh://git@github.com/"
+
+# --- dev-sandbox tools you actually use, re-added (gh, uv+uvx, pnpm) ---
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/* \
+ && curl -LsSf https://astral.sh/uv/install.sh | sh \
+ && npm install -g pnpm
+
+# --- AWS CLI v2 (self-contained installer; not a single managed binary) ---
+RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip \
+ && unzip -q /tmp/awscliv2.zip -d /tmp \
+ && /tmp/aws/install \
+ && rm -rf /tmp/aws /tmp/awscliv2.zip
+
+# --- mise: owns the version-managed toolchain per repo mise.toml ---
+RUN curl -fsSL https://mise.run | sh \
+ && ln -sf /root/.local/bin/mise /usr/local/bin/mise
+
+# mise SHIMS on PATH (not `mise activate`): resolve tools in non-interactive
+# `docker exec` shells with no per-shell hook. Shims dir first so repo-pinned
+# versions win; system node/uv stay as fallback.
+ENV PATH="/root/.local/share/mise/shims:/root/.local/bin:${PATH}"
+
+# Ship sane global defaults (latest stable as of 2026-06). Repos override
+# per-project via their own mise.toml; `mise install` (the on_create hook) fetches
+# whatever they pin. node@24 is backward-compatible with the node22 the Claude
+# adapter runs under, so the shim shadowing it is safe.
+RUN mise use -g \
+      python@3.14 \
+      node@24 \
+      terraform \
+ && mise reshim \
+ && mise ls
+
+# --- CLIs we always want at latest, installed directly (not version-pinned) ---
+# ast-grep (+ sg), crane, tilt, just, and sentry-cli (hard dep of the `sentry`
+# skill). NOTE: no inline `#` comments inside the RUN below — backslash line
+# continuation joins it into one shell line, so a `#` would eat the rest.
+RUN set -eux; \
+    ARCH="$(uname -m)"; \
+    curl -fsSL "https://github.com/ast-grep/ast-grep/releases/latest/download/app-${ARCH}-unknown-linux-gnu.zip" -o /tmp/sg.zip; \
+    unzip -o /tmp/sg.zip -d /usr/local/bin; \
+    rm /tmp/sg.zip; \
+    case "$ARCH" in x86_64) CRANE_ARCH=x86_64 ;; aarch64) CRANE_ARCH=arm64 ;; *) CRANE_ARCH="$ARCH" ;; esac; \
+    curl -fsSL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz" -o /tmp/crane.tgz; \
+    tar -xzf /tmp/crane.tgz -C /usr/local/bin crane; \
+    rm /tmp/crane.tgz; \
+    curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash; \
+    curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin; \
+    curl -sL https://sentry.io/get-cli/ | sh
+
+# For interactive terminals, also activate mise.
+RUN printf 'eval "$(/usr/local/bin/mise activate bash)"\n' > /etc/profile.d/zz-mise.sh \
+ && chmod +x /etc/profile.d/zz-mise.sh
+
+# --- Playwright (e2e) + headless Chromium, shared with the Mermaid skills ---
+# Ubuntu 26.04 is too new for Playwright's platform map, so `--with-deps` refuses
+# to pick a browser build or install deps. Two-part workaround that builds + runs:
+#   1. PLAYWRIGHT_HOST_PLATFORM_OVERRIDE pins it to the (forward-compatible) 24.04
+#      build. arm64 default; for an amd64 build pass
+#      --build-arg PLAYWRIGHT_PLATFORM=ubuntu24.04.
+#   2. The chromium runtime libs are already apt-installed above (the 26.04 t64
+#      set), and PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1 stops install/launch
+#      from throwing on the unrecognized OS.
+# A repo pinning a different @playwright/test version still works: it fetches its
+# matching browser into the same dir (no root; deps + override already in place).
+# The symlink gives Puppeteer (draw-mermaid-diagram / draw-infra-diagram) a stable
+# chromium so it skips its own ~100MB download. `npx` resolves via the mise
+# node@24 shims on PATH above.
+ARG PLAYWRIGHT_PLATFORM=ubuntu24.04-arm64
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=${PLAYWRIGHT_PLATFORM} \
+    PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
+RUN npx -y playwright@latest install chromium \
+ && ln -sf "$(ls -d /ms-playwright/chromium-*/chrome-linux/chrome | head -n1)" /usr/local/bin/chromium \
+ && chmod -R a+rx /ms-playwright
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/local/bin/chromium \
+    PUPPETEER_SKIP_DOWNLOAD=1
+
+WORKDIR /workspace

--- a/aoe/config.example.toml
+++ b/aoe/config.example.toml
@@ -1,0 +1,55 @@
+# AOE config — verified against the agent-of-empires source (config.rs, repo_config.rs,
+# runtime_base.rs). Global file lives at:
+#   macOS:  ~/.agent-of-empires/config.toml
+#   Linux:  ~/.config/agent-of-empires/config.toml  ($XDG_CONFIG_HOME)
+# Per-repo override: .agent-of-empires/config.toml (legacy .aoe/config.toml still read).
+
+[sandbox]
+enabled_by_default = true
+default_image = "sontek/aoe-devmachine:latest"   # built from ./Dockerfile
+
+# Mount ~/.ssh (ro) so git push/pull over SSH works in-container.
+mount_ssh = true
+
+# Forward credentials from the host (never bake secrets into the image).
+#   "KEY"        -> forward host value      "KEY=VALUE" -> literal
+#   "KEY=$VAR"   -> read named host var     "KEY=$$lit" -> literal starting with $
+environment = [
+  "AWS_PROFILE",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "GH_TOKEN",
+]
+
+# Docker access for the agent: host-socket passthrough (docker-OUT-of-docker —
+# launched containers are SIBLINGS on the host daemon, not nested). AOE has no
+# privileged/DinD mode, so this is the only option. Add ~/.aws (ro) for SSO cache.
+extra_volumes = [
+  "/var/run/docker.sock:/var/run/docker.sock",
+  # "/Users/john/.aws:/root/.aws:ro",
+]
+
+# Expose in-sandbox dev servers to the host. CREATE-TIME ONLY — declare every
+# port up front; adding one later requires recreating the session container.
+# (Irrelevant for compose/Tilt siblings — those publish on the host daemon directly.)
+port_mappings = ["3000:3000", "5432:5432"]
+
+# Optional resource caps.
+# cpu_limit = "4"
+# memory_limit = "8g"
+
+[worktree]
+enabled = true
+# Bare-repo layout keeps .git inside /workspace so git works in-container.
+# AOE auto-detects it; this template is the per-branch worktree path.
+bare_repo_path_template = "./{branch}"
+auto_cleanup = true
+
+[hooks]
+# Runs once at session creation; a hard failure ABORTS setup. `mise trust` is
+# required because mise refuses to auto-run an untrusted repo config.
+on_create = ["mise trust --yes", "mise install"]
+# Runs every session start; failures only log.
+# on_launch = ["docker compose up -d db"]
+# on_destroy = ["docker compose down"]

--- a/dotfiles/colima/.config/colima/_templates/default.yaml
+++ b/dotfiles/colima/.config/colima/_templates/default.yaml
@@ -1,0 +1,43 @@
+# Colima default template (managed by stow: `just install-dotfiles`).
+#
+# Colima seeds every NEW profile from this file (`colima start <name>`), so it
+# defines the default *shape* of our VMs. It does NOT rewrite already-created
+# profiles (e.g. the existing `default`), and per-profile `--flags` override it.
+#
+# NOTE: this sets VM SHAPE only. Software bootstrap (apt deps, Nix, ~/code
+# symlinks) is NOT done here — Colima `provision:` scripts run at early boot,
+# BEFORE the VM's DNS is up, so network steps fail intermittently. The bootstrap
+# runs post-start instead, over ssh, from the `just vm-up` recipe (vm-bootstrap.sh).
+
+# Container runtime. A template MUST set this: when a template is present Colima
+# seeds new profiles from it, and an absent runtime resolves to '' and fails with
+# "unsupported container runtime ''" (it does NOT fall back to the --runtime default).
+runtime: docker
+
+# Apple Virtualization.framework + virtiofs = the fast native path on Apple Silicon.
+# NOTE: mountType cannot be changed after a VM is created.
+vmType: vz
+mountType: virtiofs
+
+# Pin explicit public resolvers. Colima's default host-resolver proxies DNS
+# through the Mac and is flaky here -- intermittent failures left runtime DNS
+# broken. Reliable upstreams keep resolution working once the VM is up.
+dns:
+  - 1.1.1.1
+  - 8.8.8.8
+  - 4.2.2.2
+  - 4.2.2.1
+
+# Forward the host SSH agent into the VM so `git clone git@github.com:...` uses
+# your Mac's keys WITHOUT the private key ever living on the VM disk (keeps the
+# "no ~/.ssh in the VM" isolation). Trade-off: while you're connected, processes
+# in the VM can use the agent to auth as you -- for tighter control of what an
+# agent can reach, use a scoped GH_TOKEN over HTTPS instead.
+forwardAgent: true
+
+# Only share our source tree — not the rest of $HOME. Same path inside the VM
+# (/Users/<you>/code), which also makes docker-compose/tilt bind mounts resolve.
+# Override per-profile when a VM needs something different.
+mounts:
+  - location: ~/code
+    writable: true

--- a/dotfiles/ssh/.ssh/config
+++ b/dotfiles/ssh/.ssh/config
@@ -1,3 +1,5 @@
+Include /Users/john/.config/colima/ssh_config
+
 Include /Users/john/.ssh/conductor_config
 
 Include ~/.orbstack/ssh/config

--- a/justfile
+++ b/justfile
@@ -37,12 +37,16 @@ install-system-apps:
   @just install-nix "cheat"
   @just install-nix "cmake"
   @just install-nix "cairo"
+  @just install-nix "colima"
   @just install-nix "colordiff"
   @just install-nix "coreutils"
   @just install-nix "crane"
   @just install-nix "cue"
   @just install-nix "delta"
   @just install-nix "direnv"
+  @just install-nix "docker-client"
+  @just install-nix "docker-compose"
+  @just install-nix "docker-credential-helpers"
   @just install-nix "docker-ls"
   @just install-nix "duf"
   @just install-nix "dwdiff"
@@ -72,7 +76,7 @@ install-system-apps:
   @just install-nix "libgit2"
   @just install-nix "libffi"
   @just install-nix "libpng"
-  @just install-nix "loc"
+  @just install-nix "tokei"
   @just install-nix "lz4"
   @just install-nix "minikube"
   @just install-nix "ncurses"
@@ -144,6 +148,52 @@ install-dotfiles:
 # Removes all the dotfiles
 remove-dotfiles:
   cd dotfiles && stow --verbose=1 --delete --target=$HOME */
+
+# --- Dev VMs (Colima) ----------------------------------------------------
+# One Linux VM per project, NAMED AFTER its ~/code subdir, so each VM mounts
+# ONLY that project and can't see your other projects or $HOME:
+#   `just vm-up drape`     -> profile "drape",    mounts ~/code/drape
+#   `just vm-up stacklet`  -> profile "stacklet", mounts ~/code/stacklet
+# vz/virtiofs + the no-$HOME default also come from the stowed template
+# (~/.config/colima/_templates/default.yaml); the --mount here narrows it to the
+# one project (a flag mount replaces the template's broader default).
+#
+# RAM note: an 18GiB host can't comfortably run two 8GiB VMs at once, so the
+# defaults are modest (6 CPU / 6 GiB) to let two coexist. Bump per-invocation
+# for a single heavy VM: `just vm-up drape 8 12`. Sizing changes apply after a
+# down + up. Disk is thin-provisioned, so 100 is a ceiling, not upfront cost.
+#
+# Usage: vm-up <name> [cpu] [mem] [disk] | vm-down/vm-ssh/vm-status <name> | vm-list
+#
+# Create or start a project VM (Colima profile + ~/code/<name> mount), then
+# provision it. Bootstrap runs AFTER start (over ssh) because Colima's boot-time
+# provision scripts run before DNS is up; post-start it's reliable + visible.
+vm-up name cpu="6" memory="6" disk="100":
+  colima start {{name}} --runtime docker --vm-type vz --mount-type virtiofs --ssh-agent \
+    --cpu {{cpu}} --memory {{memory}} --disk {{disk}} \
+    --mount "$HOME/code/{{name}}:w"
+  @just vm-bootstrap {{name}}
+
+# Provision a running VM (idempotent): ~/code symlinks, apt prereqs (just/rg/curl),
+# Nix. Streams output here. Re-runnable any time; also used by `vm-up`.
+vm-bootstrap name:
+  colima ssh -p {{name}} -- bash -s < {{justfile_directory()}}/vm-bootstrap.sh
+
+# Stop a VM (frees RAM/CPU; disk + everything installed inside persists)
+vm-down name:
+  colima stop {{name}}
+
+# Shell into a VM
+vm-ssh name:
+  colima ssh -p {{name}}
+
+# Show a VM's status and address
+vm-status name:
+  colima status {{name}}
+
+# List all VMs and their state
+vm-list:
+  colima list
 
 asdf_plugins := "nodejs python golang helm yarn poetry kubectl kustomize terraform terragrunt postgres pnpm sentinel skaffold tilt rust kops yq jq"
 # Configure ASDF with all desired plugins

--- a/vm-bootstrap.sh
+++ b/vm-bootstrap.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Provision a Colima dev VM AFTER it has booted, when DNS/networking is up.
+# Piped over ssh by the `just vm-up` / `just vm-bootstrap` recipes:
+#   colima ssh -p <vm> -- bash -s < vm-bootstrap.sh
+#
+# Why post-start instead of a Colima `provision:` boot script: cloud-init
+# provision scripts run before the VM's DNS service is ready, so apt's index
+# comes back partial ("Unable to locate package just/ripgrep") and slow apt/Nix
+# can blow past lima's boot-script timeout and fail the whole `colima start`.
+# Running it here makes the VM start fast + reliable, streams output to your
+# terminal, and a failure never blocks the VM — just re-run `just vm-bootstrap`.
+#
+# Idempotent: safe to run on every `vm-up` and to re-run by hand.
+set -euo pipefail
+
+# Symlink whatever project is mounted under /Users/*/code/* to a clean
+# ~/code/<name> path (runs as the user; no network needed).
+mkdir -p "$HOME/code"
+for d in /Users/*/code/*/; do
+  [ -d "$d" ] || continue
+  ln -sfn "${d%/}" "$HOME/code/$(basename "$d")"
+done
+
+# One-time bootstrap: homies prerequisites (just + ripgrep, used by its justfile)
+# plus curl/xz-utils, then Determinate Nix. Sentinel-guarded so it runs once.
+if [ ! -f /var/lib/.homies-bootstrap-done ]; then
+  export DEBIAN_FRONTEND=noninteractive
+  sudo -E apt-get update
+  sudo -E apt-get -y install curl xz-utils just ripgrep
+  if [ ! -e /nix ] && ! command -v nix >/dev/null 2>&1; then
+    curl --retry 3 --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+      | sudo sh -s -- install --no-confirm
+  fi
+  sudo touch /var/lib/.homies-bootstrap-done
+fi
+
+echo "[vm-bootstrap] done — just/ripgrep/curl + nix ready; ~/code symlinks in place"


### PR DESCRIPTION
Sets up a reproducible dev environment for agent-of-empires work, in two layers.

A slim, Claude-only AOE sandbox image (built on the AOE base, verified launching Claude end-to-end through `aoe`) plus an example `aoe` config.

Colima-backed Linux VMs, one isolated VM per project. `just vm-up <name>` spins a VM that mounts only that project's `~/code/<name>` (not the rest of $HOME), pins reliable public DNS, and forwards the host SSH agent so git works without putting a private key on the VM. Each VM is a normal Linux box for running the agent plus its docker/tilt/compose stack.

Why a VM per project instead of the AOE container alone: it gives a clean isolation boundary (a sandbox escape stays in the VM and can't reach other projects or host secrets), and lets the agent drive a real docker daemon for `just dev` without exposing the host's.

One non-obvious choice worth a look during review: the VM software bootstrap (apt prereqs + Nix) runs after the VM is up, over ssh, not as a Colima boot-time provision script. Boot-time provisioning runs before the VM's DNS is ready, which made apt fail intermittently and could stall the whole start past lima's timeout. Post-start it's reliable and streams output to the terminal.
