### PR TITLE
feat: add hunk diff viewer, swap rtx/loc, add nix build-user repair

### DIFF
--- a/dotfiles/git/.gitconfig
+++ b/dotfiles/git/.gitconfig
@@ -15,16 +15,9 @@
     helper = store
 
 [core]
-    pager = delta
-
-[interactive]
-    diffFilter = delta --color-only
-
-[delta]
-    navigate = true    # use n and N to move between diff sections
-    light = false
-    side-by-side = true
-    line-numbers = true
+    # hunk (github:modem-dev/hunk) is the pager for all paged git output,
+    # replacing delta. `git diff`/`show`/`log` open in hunk's review TUI.
+    pager = hunk pager
 
 [merge]
     conflictstyle = diff3

--- a/justfile
+++ b/justfile
@@ -179,14 +179,19 @@ remove-dotfiles:
 #
 # Usage: vm-up <name> [cpu] [mem] [disk] | vm-down/vm-ssh/vm-status <name> | vm-list
 #
-# Create or start a project VM (Colima profile + ~/code/<name> mount), then
-# provision it. Bootstrap runs AFTER start (over ssh) because Colima's boot-time
-# provision scripts run before DNS is up; post-start it's reliable + visible.
+# Create or start a project VM (Colima profile), then provision it. Mounts the
+# named project (~/code/<name>) PLUS ~/code/sontek (homies, sontek-skills, ...)
+# so your own tooling is available in every VM. Bootstrap runs AFTER start (over
+# ssh) because Colima's boot-time provision scripts run before DNS is up.
 vm-up name cpu="6" memory="6" disk="100":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  mounts=(--mount "$HOME/code/{{name}}:w")
+  # Always include ~/code/sontek, unless this IS the sontek VM (no duplicate mount).
+  [ "{{name}}" = "sontek" ] || mounts+=(--mount "$HOME/code/sontek:w")
   colima start {{name}} --runtime docker --vm-type vz --mount-type virtiofs --ssh-agent \
-    --cpu {{cpu}} --memory {{memory}} --disk {{disk}} \
-    --mount "$HOME/code/{{name}}:w"
-  @just vm-bootstrap {{name}}
+    --cpu {{cpu}} --memory {{memory}} --disk {{disk}} "${mounts[@]}"
+  just vm-bootstrap {{name}}
 
 # Provision a running VM (idempotent): ~/code symlinks, apt prereqs (just/rg/curl),
 # Nix. Streams output here. Re-runnable any time; also used by `vm-up`.

--- a/justfile
+++ b/justfile
@@ -19,6 +19,20 @@ install-nix nix_apps args="":
       fi \
   done
 
+# Install an app from its own flake (not in nixpkgs), e.g. 'just install-flake
+# "github:owner/repo"'. --accept-flake-config trusts the flake's declared cache.
+install-flake flake_ref:
+  @if nix profile list | rg -q -F "{{flake_ref}}"; then \
+      echo "Flake {{flake_ref}} already installed, skipping"; \
+  else \
+      echo "Installing {{flake_ref}}"; \
+      nix profile install --accept-flake-config "{{flake_ref}}"; \
+  fi
+
+# Install apps that ship their own flake rather than living in nixpkgs
+install-flake-apps:
+  @just install-flake "github:modem-dev/hunk"
+
 # Install fun apps
 install-fun-apps: (install-nix "boxes cowsay figlet fortune lolcat toilet neofetch")
 
@@ -79,6 +93,7 @@ install-system-apps:
   @just install-nix "tokei"
   @just install-nix "lz4"
   @just install-nix "minikube"
+  @just install-nix "mise"
   @just install-nix "ncurses"
   @just install-nix "ngrok" "--impure"
   @just install-nix "openssl"
@@ -95,7 +110,6 @@ install-system-apps:
   @just install-nix "neovim"
   @just install-nix "readline"
   @just install-nix "ripgrep"
-  @just install-nix "rtx"
   @just install-nix "sd"
   @just install-nix "shellcheck"
   @just install-nix "starship"
@@ -123,7 +137,7 @@ install-sre-apps:
   @just install-nix "mage golangci-lint e1s granted"
 
 # Install all applications
-install: install-system-apps install-sre-apps install-fun-apps
+install: install-system-apps install-sre-apps install-fun-apps install-flake-apps
   @echo "Done installing all packages"
 
 # Upgrade all installed applications

--- a/repair-nix-build-users.sh
+++ b/repair-nix-build-users.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Repair Nix multi-user build users on macOS.
+#
+# After a macOS upgrade, the OS can reclaim low UIDs that Nix's build users used
+# (e.g. _nixbld1..7 sat at UIDs 301..307, which macOS later handed to its own
+# daemons like _modelmanagerd). The `nixbld` group still lists every _nixbldN,
+# but some of those users no longer exist, so any from-source Nix build fails:
+#     error: the user '_nixbld1' in the group 'nixbld' does not exist
+#
+# This recreates each missing _nixbld user at a FREE UID and restarts the daemon.
+# Idempotent: existing users are left untouched. Safe to re-run after the next
+# macOS upgrade if it happens again.
+set -euo pipefail
+
+# Re-exec under sudo if not root (one password prompt).
+if [ "$(id -u)" -ne 0 ]; then
+  echo "elevating with sudo..."
+  exec sudo "$0" "$@"
+fi
+
+GROUP="nixbld"
+GID="$(dscl . -read "/Groups/$GROUP" PrimaryGroupID 2>/dev/null | awk '{print $2}')"
+if [ -z "$GID" ]; then
+  echo "error: group '$GROUP' not found — is multi-user Nix installed?" >&2
+  exit 1
+fi
+
+# Expected build users = whatever the group lists (e.g. _nixbld1.._nixbld32).
+members="$(dscl . -read "/Groups/$GROUP" GroupMembership 2>/dev/null \
+  | tr ' ' '\n' | grep -E '^_nixbld[0-9]+$' | sort -u)"
+if [ -z "$members" ]; then
+  echo "error: no _nixbld members listed in group '$GROUP'" >&2
+  exit 1
+fi
+
+# Start scanning for free UIDs just above the highest existing _nixbld UID.
+max_uid=0
+for u in $members; do
+  # `|| uid=""` so a missing user's failed read doesn't trip `set -e`.
+  uid="$(dscl . -read "/Users/$u" UniqueID 2>/dev/null | awk '{print $2}')" || uid=""
+  if [ -n "$uid" ] && [ "$uid" -gt "$max_uid" ]; then
+    max_uid="$uid"
+  fi
+done
+next=$(( max_uid > 0 ? max_uid + 1 : 350 ))
+
+created=0
+for u in $members; do
+  if dscl . -read "/Users/$u" >/dev/null 2>&1; then
+    continue   # exists — leave it alone
+  fi
+  # advance to the next genuinely-free UID
+  while dscl . -search /Users UniqueID "$next" 2>/dev/null | grep -q .; do
+    next=$(( next + 1 ))
+  done
+  uid="$next"; next=$(( next + 1 ))
+  n="${u#_nixbld}"
+  echo "creating $u (UID $uid)"
+  dscl . -create "/Users/$u" UniqueID "$uid"
+  dscl . -create "/Users/$u" PrimaryGroupID "$GID"
+  dscl . -create "/Users/$u" NFSHomeDirectory /var/empty
+  dscl . -create "/Users/$u" UserShell /usr/bin/false
+  dscl . -create "/Users/$u" RealName "Nix build user $n"
+  created=$(( created + 1 ))
+done
+
+echo "recreated $created build user(s) (gid $GID)."
+
+# Restart the daemon so it picks up the new users (label varies by installer,
+# so detect it instead of guessing).
+label="$(launchctl list 2>/dev/null | awk '/nix-daemon/ {print $3; exit}')"
+if [ -n "$label" ]; then
+  echo "restarting system/$label"
+  launchctl kickstart -k "system/$label" || true
+else
+  echo "note: nix-daemon launchd label not found — if builds still fail, reboot."
+fi
+
+echo "done."

--- a/vm-bootstrap.sh
+++ b/vm-bootstrap.sh
@@ -13,25 +13,38 @@
 # Idempotent: safe to run on every `vm-up` and to re-run by hand.
 set -euo pipefail
 
+log() { printf '\n==> [vm-bootstrap] %s\n' "$*"; }
+
+log "starting on $(hostname) (user $(whoami))"
+
 # Symlink whatever project is mounted under /Users/*/code/* to a clean
 # ~/code/<name> path (runs as the user; no network needed).
+log "linking mounted projects into ~/code ..."
 mkdir -p "$HOME/code"
 for d in /Users/*/code/*/; do
   [ -d "$d" ] || continue
   ln -sfn "${d%/}" "$HOME/code/$(basename "$d")"
+  echo "    ~/code/$(basename "$d") -> ${d%/}"
 done
 
 # One-time bootstrap: homies prerequisites (just + ripgrep, used by its justfile)
 # plus curl/xz-utils, then Determinate Nix. Sentinel-guarded so it runs once.
-if [ ! -f /var/lib/.homies-bootstrap-done ]; then
+if [ -f /var/lib/.homies-bootstrap-done ]; then
+  log "system bootstrap already done (sentinel present) — skipping apt + nix"
+else
   export DEBIAN_FRONTEND=noninteractive
+  log "apt: updating index + installing curl xz-utils just ripgrep ..."
   sudo -E apt-get update
   sudo -E apt-get -y install curl xz-utils just ripgrep
   if [ ! -e /nix ] && ! command -v nix >/dev/null 2>&1; then
+    log "nix: installing Determinate Nix (this is the slow step) ..."
     curl --retry 3 --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
       | sudo sh -s -- install --no-confirm
+  else
+    log "nix: already installed — skipping"
   fi
   sudo touch /var/lib/.homies-bootstrap-done
+  log "system bootstrap complete (sentinel written)"
 fi
 
-echo "[vm-bootstrap] done — just/ripgrep/curl + nix ready; ~/code symlinks in place"
+log "done — just/ripgrep/curl + nix ready; ~/code symlinks in place"


### PR DESCRIPTION
Adds hunk (github:modem-dev/hunk) as the git diff pager, replacing delta. hunk lives in its own flake rather than nixpkgs, so this also adds a small `install-flake` helper next to the existing `install-nix`, for tools that ship a flake instead of being packaged upstream.

Two upstream nixpkgs changes are folded in because they were halting the install: rtx was renamed to mise, and loc was removed (tokei is the maintained replacement).

A couple of Colima dev-VM tweaks ride along: every VM now mounts `~/code/sontek` (homies, sontek-skills) alongside its named project, so your own tooling is available everywhere while other projects stay isolated, and `vm-bootstrap` now logs begin/end and per-phase markers so it is obvious work is happening.

The piece worth a careful look is `repair-nix-build-users.sh`. Installing hunk surfaced a latent macOS problem: a system upgrade had reclaimed the low UIDs the nix build users sat on and handed them to macOS daemons, so the nixbld group referenced users that no longer existed and every from-source nix build failed. The script recreates the missing build users at free UIDs and restarts the daemon. It is idempotent and re-runnable if a future upgrade does the same thing.