### PR TITLE
feat: Colima dev-VM workflow (root disk, zsh shell, aoe, sandboxing doc)

### DIFF
--- a/CLAUDE-SANDBOXING.md
+++ b/CLAUDE-SANDBOXING.md
@@ -1,0 +1,55 @@
+# Sandboxing Claude
+
+I give coding agents broad permissions, and they can be steered by whatever they
+read (prompt injection). So I don't trust the agent; I trust the box it runs in.
+Each project gets its own Colima Linux VM and the agent lives inside it. The VM
+is the boundary.
+
+```
+just vm-up <project>
+```
+
+## Why a VM is the right boundary
+
+**It's a real virtual machine, not a container.** Colima runs it under Apple's
+Virtualization framework. Worst case, a compromised agent becomes root inside the
+VM, and that is where it stops: the hypervisor boundary keeps it off the macOS
+host, the kernel, and anything I didn't mount. A container that shares the host
+kernel wouldn't give me that.
+
+**Only the project is mounted, nothing else.** The VM gets `~/code/<project>`
+plus `~/code/sontek` (my dotfiles and tooling), and that is it. No `~`, no
+`~/.ssh`, no `~/.aws`, no other projects. An escape sees the code it is working
+on and none of my secrets.
+
+**No host Docker socket.** The VM runs its own Docker daemon, so `just dev`,
+compose, and tilt are containers inside the VM. I never pass in the host socket;
+that would let the agent run a privileged container that mounts `/` and takes the
+Mac. It can't reach the host daemon.
+
+**Git without a key in the VM.** I forward the host SSH agent in, so `git push`
+uses my keys without the private key ever touching the VM disk. Nothing to
+exfiltrate.
+
+**AWS without my real credentials.** The VM inherits no AWS access. I run
+`aws sso login` inside it against a sandbox account, which gives a short-lived,
+scoped token that stays in the VM. My `~/.aws` (prod profiles, long-lived keys)
+is never mounted, so the agent can't escalate into anything I didn't hand it.
+
+## What an escape can still reach
+
+I'm not pretending it's airtight. Inside those limits a compromised agent can
+read or change the mounted project and my `~/code/sontek` tooling, and while I'm
+connected with the agent forwarded it can use that agent to act as me on GitHub.
+When I want it tighter:
+
+- A fine-grained, repo-scoped `GH_TOKEN` over HTTPS instead of agent forwarding.
+- Sandbox AWS accounts only; I never SSO into prod from an agent's VM.
+- One project per VM, so a bad one doesn't touch the rest of my work.
+
+## Short version
+
+The agent lives in a disposable Linux VM that sees its project and my tooling,
+runs its own Docker, borrows my SSH agent without holding the key, and only has
+the AWS access I log into inside it. A bad day for the agent is a bad day for
+that VM, not for my Mac, my keys, or my cloud accounts.

--- a/dotfiles/starship/.config/starship.toml
+++ b/dotfiles/starship/.config/starship.toml
@@ -1,6 +1,6 @@
 add_newline = true
 format = '''[$cmd_duration](bold purple)
-[$hostname](bold red)[$git_branch](bold blue) [$kubernetes](bold cyan) [$aws](bold orange) [$python](bold blue)
+$hostname[$git_branch](bold blue) [$kubernetes](bold cyan) [$aws](bold orange) [$python](bold blue)
 [$directory](bold green)
 [$character](bold yellow)
 '''
@@ -39,9 +39,14 @@ symbol = "tf(bold)"
 format = "[$symbol $version $workspace]($style)"
   
 [hostname]
-ssh_only = false
-disabled = true
-format =  "[$hostname](bold red) "
+# Show the hostname only over SSH, which is exactly when we're inside a Colima
+# dev VM (`colima ssh` / `just vm-ssh`). The local Mac shell isn't SSH, so it
+# stays clean; VMs render e.g. `colima-stacklet` as a white-on-red badge so the
+# two shells are unmistakable. The color lives here, so the main `format` just
+# places `$hostname` with no wrapper of its own (avoids double-styling).
+ssh_only = true
+disabled = false
+format =  "[ $hostname ](bold white bg:red) "
 
 [package]
 disabled = true

--- a/dotfiles/zsh/.config/zsh/exports.zsh
+++ b/dotfiles/zsh/.config/zsh/exports.zsh
@@ -77,7 +77,11 @@ then
     eval "$(atuin init zsh --disable-up-arrow)"
 fi
 
-# Setup the KUBECONFIG env var to use ~/kubeconfigs
-export KUBECONFIG=$(find ~/kubeconfigs -type f|xargs|tr -s '[:blank:]' ':')
+# Setup the KUBECONFIG env var from ~/kubeconfigs, only if it exists and has
+# files (it's absent on machines/VMs without kube configs, where an unguarded
+# find errors on every shell startup).
+if [ -d ~/kubeconfigs ] && [ -n "$(find ~/kubeconfigs -type f 2>/dev/null)" ]; then
+  export KUBECONFIG=$(find ~/kubeconfigs -type f|xargs|tr -s '[:blank:]' ':')
+fi
 . "${XDG_CONFIG_HOME}/zsh/dynamic-exports.zsh"
 

--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ install-flake-apps:
   @just install-flake "github:modem-dev/hunk"
 
 # Install fun apps
-install-fun-apps: (install-nix "boxes cowsay figlet fortune lolcat toilet neofetch")
+install-fun-apps: (install-nix "boxes cowsay figlet fortune lolcat toilet fastfetch")
 
 # Install apps for every day use
 install-system-apps:
@@ -174,23 +174,28 @@ remove-dotfiles:
 #
 # RAM note: an 18GiB host can't comfortably run two 8GiB VMs at once, so the
 # defaults are modest (6 CPU / 6 GiB) to let two coexist. Bump per-invocation
-# for a single heavy VM: `just vm-up drape 8 12`. Sizing changes apply after a
-# down + up. Disk is thin-provisioned, so 100 is a ceiling, not upfront cost.
+# for a single heavy VM: `just vm-up drape 8 12 150`. Sizing changes apply after
+# a down + up. Both disks are thin-provisioned (sparse), so the numbers are
+# ceilings, not upfront cost; root_disk sizes /nix (the toolchain), disk sizes
+# the container-runtime store.
 #
-# Usage: vm-up <name> [cpu] [mem] [disk] | vm-down/vm-ssh/vm-status <name> | vm-list
+# Usage: vm-up <name> [cpu] [mem] [disk] [root_disk] | vm-down/vm-ssh/vm-status <name> | vm-list
 #
 # Create or start a project VM (Colima profile), then provision it. Mounts the
 # named project (~/code/<name>) PLUS ~/code/sontek (homies, sontek-skills, ...)
 # so your own tooling is available in every VM. Bootstrap runs AFTER start (over
 # ssh) because Colima's boot-time provision scripts run before DNS is up.
-vm-up name cpu="6" memory="6" disk="100":
+vm-up name cpu="6" memory="6" disk="100" root_disk="100":
   #!/usr/bin/env bash
   set -euo pipefail
   mounts=(--mount "$HOME/code/{{name}}:w")
   # Always include ~/code/sontek, unless this IS the sontek VM (no duplicate mount).
   [ "{{name}}" = "sontek" ] || mounts+=(--mount "$HOME/code/sontek:w")
+  # Two sparse disks: --root-disk holds the OS + /nix (the toolchain), --disk is
+  # Colima's dedicated container-runtime disk (docker/containerd). The default
+  # root disk is only 20 GiB, which /nix overflows, so size it explicitly.
   colima start {{name}} --runtime docker --vm-type vz --mount-type virtiofs --ssh-agent \
-    --cpu {{cpu}} --memory {{memory}} --disk {{disk}} "${mounts[@]}"
+    --cpu {{cpu}} --memory {{memory}} --disk {{disk}} --root-disk {{root_disk}} "${mounts[@]}"
   just vm-bootstrap {{name}}
 
 # Provision a running VM (idempotent): ~/code symlinks, apt prereqs (just/rg/curl),

--- a/justfile
+++ b/justfile
@@ -32,6 +32,7 @@ install-flake flake_ref:
 # Install apps that ship their own flake rather than living in nixpkgs
 install-flake-apps:
   @just install-flake "github:modem-dev/hunk"
+  @just install-flake "github:agent-of-empires/agent-of-empires"
 
 # Install fun apps
 install-fun-apps: (install-nix "boxes cowsay figlet fortune lolcat toilet fastfetch")

--- a/vm-bootstrap.sh
+++ b/vm-bootstrap.sh
@@ -33,15 +33,22 @@ if [ -f /var/lib/.homies-bootstrap-done ]; then
   log "system bootstrap already done (sentinel present) — skipping apt + nix"
 else
   export DEBIAN_FRONTEND=noninteractive
-  log "apt: updating index + installing curl xz-utils just ripgrep ..."
+  log "apt: updating index + installing curl xz-utils just ripgrep zsh ..."
   sudo -E apt-get update
-  sudo -E apt-get -y install curl xz-utils just ripgrep
+  sudo -E apt-get -y install curl xz-utils just ripgrep zsh
   if [ ! -e /nix ] && ! command -v nix >/dev/null 2>&1; then
     log "nix: installing Determinate Nix (this is the slow step) ..."
     curl --retry 3 --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
       | sudo sh -s -- install --no-confirm
   else
     log "nix: already installed — skipping"
+  fi
+  # Make zsh the login shell so `colima ssh` / `just vm-ssh` lands in zsh.
+  ZSH_BIN="$(command -v zsh || true)"
+  if [ -n "$ZSH_BIN" ]; then
+    grep -qxF "$ZSH_BIN" /etc/shells || echo "$ZSH_BIN" | sudo tee -a /etc/shells >/dev/null
+    sudo chsh -s "$ZSH_BIN" "$(whoami)"
+    log "login shell set to $ZSH_BIN"
   fi
   sudo touch /var/lib/.homies-bootstrap-done
   log "system bootstrap complete (sentinel written)"


### PR DESCRIPTION
Rounds out the Colima per-project dev-VM workflow: the VMs now finish provisioning, are usable, are clearly distinct from the local shell, and the security model is written down.

Disk: the VM's root filesystem (where `/nix` lives) defaulted to 20 GiB and the full nix toolchain overflowed it, while Colima's separate runtime disk sat empty. `vm-up` now takes a `root_disk` argument (default 100) wired to `--root-disk`. Also swaps `neofetch` (removed from nixpkgs) for `fastfetch`.

Shell: every VM installs zsh and uses it as the login shell, and starship shows the VM hostname as a white-on-red badge over SSH (`ssh_only`, so the Mac shell is untouched) so a VM session is unmistakable. The KUBECONFIG export is guarded so a missing `~/kubeconfigs` no longer errors on every VM shell startup.

Tooling: `aoe` (agent-of-empires) is now installed from its flake as part of `just install`, alongside hunk, on macOS and the Linux VMs.

Docs: `CLAUDE-SANDBOXING.md` explains why a Colima VM is the boundary for running coding agents (a real VM contains an escape, only the project plus my tooling are mounted, no host Docker socket, a forwarded SSH agent, in-VM SSO to a sandbox AWS account), and is honest about what an escape can still reach.