### PR TITLE
feat: ready-to-use Colima dev VMs (clean paths, toolchain, Claude + skills)

### DIFF
--- a/dotfiles/colima/.config/colima/_templates/default.yaml
+++ b/dotfiles/colima/.config/colima/_templates/default.yaml
@@ -5,7 +5,7 @@
 # profiles (e.g. the existing `default`), and per-profile `--flags` override it.
 #
 # NOTE: this sets VM SHAPE only. Software bootstrap (apt deps, Nix, ~/code
-# symlinks) is NOT done here — Colima `provision:` scripts run at early boot,
+# bind mounts) is NOT done here. Colima `provision:` scripts run at early boot,
 # BEFORE the VM's DNS is up, so network steps fail intermittently. The bootstrap
 # runs post-start instead, over ssh, from the `just vm-up` recipe (vm-bootstrap.sh).
 

--- a/dotfiles/zsh/.config/zsh/exports.zsh
+++ b/dotfiles/zsh/.config/zsh/exports.zsh
@@ -85,3 +85,17 @@ if [ -d ~/kubeconfigs ] && [ -n "$(find ~/kubeconfigs -type f 2>/dev/null)" ]; t
 fi
 . "${XDG_CONFIG_HOME}/zsh/dynamic-exports.zsh"
 
+# In a Colima dev VM (hostname colima-<project>), a fresh `vm-ssh` / `colima ssh`
+# login lands in the inherited host path (/Users/.../code/...) or $HOME. Move it
+# to the clean ~/code/<project> bind mount so tools that default to the working
+# directory (e.g. aoe) report ~/code/<project> instead of the /Users/... mount
+# path. Guarded to the VM by hostname, and only from $HOME or a /Users path so it
+# never pulls an aoe/worktree shell (already in the project) out of its dir.
+if [[ -o interactive && "$HOST" == colima-* ]]; then
+  __vm_proj="$HOME/code/${${HOST#colima-}%%.*}"
+  if [[ -d "$__vm_proj" && ( "$PWD" == "$HOME" || "$PWD" == /Users/* ) ]]; then
+    cd "$__vm_proj"
+  fi
+  unset __vm_proj
+fi
+

--- a/dotfiles/zsh/.config/zsh/exports.zsh
+++ b/dotfiles/zsh/.config/zsh/exports.zsh
@@ -89,9 +89,12 @@ fi
 # login lands in the inherited host path (/Users/.../code/...) or $HOME. Move it
 # to the clean ~/code/<project> bind mount so tools that default to the working
 # directory (e.g. aoe) report ~/code/<project> instead of the /Users/... mount
-# path. Guarded to the VM by hostname, and only from $HOME or a /Users path so it
-# never pulls an aoe/worktree shell (already in the project) out of its dir.
-if [[ -o interactive && "$HOST" == colima-* ]]; then
+# path. Skip it inside tmux: aoe runs each agent and its paired terminal (`t`) in
+# a tmux pane whose cwd is that session's worktree (often under /Users/...), and
+# auto-cd here would yank those panes back to the project root. $TMUX is the
+# discriminator (a real ssh login isn't in tmux). The hostname guard keeps the
+# Mac shell untouched.
+if [[ -o interactive && -z "$TMUX" && "$HOST" == colima-* ]]; then
   __vm_proj="$HOME/code/${${HOST#colima-}%%.*}"
   if [[ -d "$__vm_proj" && ( "$PWD" == "$HOME" || "$PWD" == /Users/* ) ]]; then
     cd "$__vm_proj"

--- a/justfile
+++ b/justfile
@@ -199,8 +199,9 @@ vm-up name cpu="6" memory="6" disk="100" root_disk="100":
     --cpu {{cpu}} --memory {{memory}} --disk {{disk}} --root-disk {{root_disk}} "${mounts[@]}"
   just vm-bootstrap {{name}}
 
-# Provision a running VM (idempotent): ~/code symlinks, apt prereqs (just/rg/curl),
-# Nix. Streams output here. Re-runnable any time; also used by `vm-up`.
+# Provision a running VM (idempotent): ~/code bind mounts, apt prereqs
+# (just/rg/curl/build-essential), Nix. Streams output here. Re-runnable any time;
+# also used by `vm-up`.
 vm-bootstrap name:
   colima ssh -p {{name}} -- bash -s < {{justfile_directory()}}/vm-bootstrap.sh
 

--- a/vm-bootstrap.sh
+++ b/vm-bootstrap.sh
@@ -71,4 +71,48 @@ else
   log "system bootstrap complete (sentinel written)"
 fi
 
-log "done: just/ripgrep/curl + nix ready; ~/code bind mounts in place"
+# Claude Code + our skills. Install the CLI (native installer, self-updating)
+# when missing, then register ~/code/sontek/sontek-skills as a plugin
+# marketplace and enable it, so our skills and subagents are available the
+# moment you run `claude` in the VM. Both steps are idempotent and run on every
+# bootstrap so a recreated VM self-heals; plugin registration is skipped when
+# the skills tree isn't mounted. python3 (system) merges the JSON so existing
+# settings are preserved.
+if ! command -v claude >/dev/null 2>&1; then
+  log "claude: installing Claude Code (native installer) ..."
+  curl -fsSL https://claude.ai/install.sh | bash
+else
+  log "claude: already installed, skipping"
+fi
+
+SKILLS_DIR="$HOME/code/sontek/sontek-skills"
+if [ -d "$SKILLS_DIR" ]; then
+  log "claude: registering sontek-skills plugin marketplace ..."
+  PYBIN=/usr/bin/python3; [ -x "$PYBIN" ] || PYBIN=python3
+  "$PYBIN" - "$SKILLS_DIR" <<'PY'
+import json, os, sys
+skills = sys.argv[1]
+cfg_dir = os.path.expanduser("~/.claude")
+cfg = os.path.join(cfg_dir, "settings.json")
+os.makedirs(cfg_dir, exist_ok=True)
+data = {}
+if os.path.exists(cfg):
+    try:
+        with open(cfg) as f:
+            data = json.load(f)
+    except (ValueError, OSError):
+        data = {}
+data.setdefault("extraKnownMarketplaces", {})["sontek-skills-local"] = {
+    "source": {"source": "directory", "path": skills}
+}
+data.setdefault("enabledPlugins", {})["sontek-skills@sontek-skills-local"] = True
+with open(cfg, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+print("    sontek-skills@sontek-skills-local enabled -> " + skills)
+PY
+else
+  log "claude: $SKILLS_DIR not mounted, skipping plugin registration"
+fi
+
+log "done: just/ripgrep/curl + nix + claude ready; ~/code bind mounts in place"

--- a/vm-bootstrap.sh
+++ b/vm-bootstrap.sh
@@ -17,14 +17,27 @@ log() { printf '\n==> [vm-bootstrap] %s\n' "$*"; }
 
 log "starting on $(hostname) (user $(whoami))"
 
-# Symlink whatever project is mounted under /Users/*/code/* to a clean
-# ~/code/<name> path (runs as the user; no network needed).
-log "linking mounted projects into ~/code ..."
+# Bind-mount whatever project is mounted under /Users/*/code/* onto a clean
+# ~/code/<name> path. A bind mount (not a symlink) is deliberate: getcwd()
+# resolves a symlink back to /Users/..., so tools that key off the working
+# directory (aoe defaults a new session to the current directory) would report
+# the ugly mount path. A bind mount is a real mount point, so the cwd stays
+# ~/code/<name>. Bind mounts don't persist across a VM stop, so this re-runs on
+# every `vm-up`. Old symlinks from earlier bootstraps are converted to mounts.
+log "bind-mounting mounted projects into ~/code ..."
 mkdir -p "$HOME/code"
 for d in /Users/*/code/*/; do
   [ -d "$d" ] || continue
-  ln -sfn "${d%/}" "$HOME/code/$(basename "$d")"
-  echo "    ~/code/$(basename "$d") -> ${d%/}"
+  name="$(basename "$d")"
+  target="$HOME/code/$name"
+  [ -L "$target" ] && rm -f "$target"
+  mkdir -p "$target"
+  if mountpoint -q "$target"; then
+    echo "    ~/code/$name already mounted"
+  else
+    sudo mount --bind "${d%/}" "$target"
+    echo "    ~/code/$name -> ${d%/} (bind)"
+  fi
 done
 
 # One-time bootstrap: homies prerequisites (just + ripgrep, used by its justfile)
@@ -33,9 +46,13 @@ if [ -f /var/lib/.homies-bootstrap-done ]; then
   log "system bootstrap already done (sentinel present) — skipping apt + nix"
 else
   export DEBIAN_FRONTEND=noninteractive
-  log "apt: updating index + installing curl xz-utils just ripgrep zsh ..."
+  # build-essential gives us a C toolchain (cc/make) so Neovim plugins with
+  # native components compile in-VM: telescope-fzf-native's libfzf.so and
+  # nvim-treesitter parsers. Without it :PackerSync fails to load the fzf
+  # extension ("cannot open shared object file: libfzf.so").
+  log "apt: updating index + installing curl xz-utils just ripgrep zsh build-essential ..."
   sudo -E apt-get update
-  sudo -E apt-get -y install curl xz-utils just ripgrep zsh
+  sudo -E apt-get -y install curl xz-utils just ripgrep zsh build-essential
   if [ ! -e /nix ] && ! command -v nix >/dev/null 2>&1; then
     log "nix: installing Determinate Nix (this is the slow step) ..."
     curl --retry 3 --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
@@ -54,4 +71,4 @@ else
   log "system bootstrap complete (sentinel written)"
 fi
 
-log "done — just/ripgrep/curl + nix ready; ~/code symlinks in place"
+log "done: just/ripgrep/curl + nix ready; ~/code bind mounts in place"


### PR DESCRIPTION
Gets a Colima dev VM ready to use out of the box: clean paths, a working compiler, Claude Code, and our skills.

aoe (and anything that defaults to the working directory) showed the project as `/Users/<you>/code/<project>` instead of `~/code/<project>`. The bootstrap symlinked the virtiofs mount into `~/code`, but getcwd resolves a symlink back to the `/Users` mount path, and aoe stores whatever the working directory reports. Bind-mounting the project onto `~/code/<project>` keeps the path clean, since a bind mount is a real mount point and getcwd stays put. A fresh VM login now also lands in `~/code/<project>`, so the working directory is already right when aoe reads it.

Native code compiles in the VM now: build-essential is installed during bootstrap, so Neovim's treesitter parsers and telescope-fzf-native (and anything else built from source) work instead of failing to load a missing `.so`.

Claude Code is installed via its native installer when missing, and `~/code/sontek/sontek-skills` is registered as a directory plugin marketplace with the plugin enabled, so our skills and subagents are available the moment you run `claude` in a VM.

Both the bind mounts and the plugin registration are reasserted on every `vm-up`, so a recreated VM comes back correct. The bind mounts in particular don't survive a VM stop, while the settings persist on the VM's own disk.