### PR TITLE
fix(dotfiles): restore real TERM and cursor-shape passthrough in tmux/zsh and VMs

### DIFF
--- a/dotfiles/tmux/.config/tmux/tmux.conf
+++ b/dotfiles/tmux/.config/tmux/tmux.conf
@@ -15,4 +15,9 @@ bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 
-set -g default-terminal "xterm-256color"
+# Advertise a full terminfo inside tmux and forward cursor-shape escapes (DECSCUSR)
+# so TUIs like the aoe/claude input box can position and style the caret. Without
+# the Ss/Se override the caret gets swallowed and you can't see where you're typing.
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ',*:Ss=\E[%p1%d q:Se=\E[ q'
+set -as terminal-features ',xterm*:RGB'

--- a/dotfiles/zsh/.config/zsh/.zshrc
+++ b/dotfiles/zsh/.config/zsh/.zshrc
@@ -1,4 +1,7 @@
-export TERM="xterm"
+# Upgrade a bare/downgraded TERM (e.g. the plain "xterm" colima ssh hands the VM)
+# to 256color, but leave richer values (xterm-kitty, tmux-256color, screen-*) alone
+# so we don't clobber the terminal's real capabilities or tmux's default-terminal.
+[[ -z "$TERM" || "$TERM" == "xterm" ]] && export TERM="xterm-256color"
 export PS1="> "
 
 # Ensure core system paths are always present (GUI-launched shells

--- a/vm-bootstrap.sh
+++ b/vm-bootstrap.sh
@@ -52,7 +52,9 @@ else
   # extension ("cannot open shared object file: libfzf.so").
   log "apt: updating index + installing curl xz-utils just ripgrep zsh build-essential ..."
   sudo -E apt-get update
-  sudo -E apt-get -y install curl xz-utils just ripgrep zsh build-essential
+  # ncurses-term ships the tmux-256color terminfo entry into /usr/share/terminfo
+  # so the apt tmux finds it (the cursor-shape fix in tmux.conf depends on it).
+  sudo -E apt-get -y install curl xz-utils just ripgrep zsh build-essential stow ncurses-term
   if [ ! -e /nix ] && ! command -v nix >/dev/null 2>&1; then
     log "nix: installing Determinate Nix (this is the slow step) ..."
     curl --retry 3 --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
@@ -113,6 +115,20 @@ print("    sontek-skills@sontek-skills-local enabled -> " + skills)
 PY
 else
   log "claude: $SKILLS_DIR not mounted, skipping plugin registration"
+fi
+
+# Symlink our terminal dotfiles into the VM so tmux + zsh behave like the host —
+# notably a real TERM (the zsh rc upgrades colima's bare "xterm" to 256color) and
+# tmux cursor-shape passthrough, so TUI cursors (aoe/claude input box) render.
+# Scoped to the terminal packages: the `claude` package's settings are managed
+# above, and the mac-only packages (kitty/alacritty/colima) aren't useful here.
+HOMIES_DIR="$HOME/code/sontek/homies"
+if [ -d "$HOMIES_DIR/dotfiles" ] && command -v stow >/dev/null 2>&1; then
+  log "stow: symlinking tmux + zsh dotfiles into \$HOME ..."
+  ( cd "$HOMIES_DIR/dotfiles" && stow --restow --target="$HOME" tmux zsh ) \
+    || log "stow: skipped/failed (non-fatal)"
+else
+  log "stow: dotfiles not mounted or stow missing — skipping dotfile symlinks"
 fi
 
 log "done: just/ripgrep/curl + nix + claude ready; ~/code bind mounts in place"


### PR DESCRIPTION
The aoe/claude TUI rendered no visible cursor inside Colima VMs, so you couldn't tell where you were typing. The root cause was the zsh rc force-exporting TERM=xterm on every shell, which downgrades even capable terminals (kitty, tmux) to the most capability-starved terminfo there is and starves the caret.

zsh now upgrades only the bare "xterm" that colima ssh hands the VM to xterm-256color and leaves richer values alone. tmux advertises tmux-256color and forwards cursor-shape (DECSCUSR) escapes so TUIs can place and style the caret. The VM bootstrap stows the tmux and zsh dotfiles and installs ncurses-term so the fix actually reaches Colima VMs, where the problem showed up.

Verified end to end in a fresh session: the caret renders and TERM resolves to tmux-256color inside the aoe pane.