### PR TITLE
feat(claude): serialize pytest across aoe worktrees via an flock hook

### DIFF
--- a/dotfiles/claude/.claude/hooks/aoe-lock.sh
+++ b/dotfiles/claude/.claude/hooks/aoe-lock.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# aoe-lock.sh — serialize expensive commands across aoe worktrees with flock.
+#
+# Registered as a PreToolUse(Bash) hook. When a Bash command matches a "lane"
+# pattern below, the hook rewrites it to run under an flock mutex so that only
+# one job per lane runs at a time on this host. flock holds the lock for the
+# lifetime of the wrapped process and the kernel releases it on exit/crash/kill,
+# so there is no stale-lock cleanup. A queued command blocks until the lock is
+# free; in practice the agent's own command timeout is the upper bound on the wait.
+#
+# Lanes are independent: a test and a deploy can run concurrently, but two tests
+# (or two deploys) queue behind each other. Edit the *_RE patterns to tune what
+# gets serialized. To limit this to aoe sessions only, gate on $AOE_INSTANCE_ID
+# near the top (see note).
+#
+# Fail-open by design: if anything is missing or unexpected, the command passes
+# through unchanged (the hook prints nothing and exits 0).
+
+input=$(cat)
+
+emit_passthrough() { exit 0; }  # no output => Claude runs the original command
+
+# Only act on Bash tool calls.
+command -v jq >/dev/null 2>&1 || emit_passthrough
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty')
+[ "$tool" = "Bash" ] || emit_passthrough
+
+# Need flock; without it we cannot lock, so pass through untouched.
+command -v flock >/dev/null 2>&1 || emit_passthrough
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+[ -n "$cmd" ] || emit_passthrough
+
+# To restrict locking to aoe sessions only, uncomment:
+#   [ -n "${AOE_INSTANCE_ID:-}" ] || emit_passthrough
+
+LOCK_DIR="/tmp/aoe-locks"
+
+# Idempotency: never double-wrap a command we already rewrote.
+case "$cmd" in
+  *"$LOCK_DIR"*) emit_passthrough ;;
+esac
+
+# --- Lane patterns (extended regex, case-insensitive). Tune these. -------------
+# Test lane: any pytest invocation (incl. `python -m pytest`, `uv run pytest`),
+# or a `just test` / `just tests` recipe.
+TEST_RE='(^|[^[:alnum:]_.-])(pytest|py\.test)([^[:alnum:]_]|$)|(^|[^[:alnum:]_.-])just([[:space:]]+[^&;|]*)?[[:space:]]+tests?([^[:alnum:]_]|$)'
+# Deploy lane: scaffolded but intentionally empty for now. Add patterns later,
+# e.g. DEPLOY_RE='terraform[[:space:]]+apply|(^|[[:space:]])just[[:space:]]+deploy'
+DEPLOY_RE=''
+# ------------------------------------------------------------------------------
+
+lane=""
+if printf '%s' "$cmd" | grep -Eiq "$TEST_RE"; then
+  lane="pytest"
+elif [ -n "$DEPLOY_RE" ] && printf '%s' "$cmd" | grep -Eiq "$DEPLOY_RE"; then
+  lane="deploy"
+fi
+
+[ -n "$lane" ] || emit_passthrough   # not an expensive command
+
+mkdir -p "$LOCK_DIR" 2>/dev/null || emit_passthrough
+lockfile="$LOCK_DIR/$lane.lock"
+
+# Wrap the original so flock owns it for its whole lifetime; %q shell-quotes it for bash -c re-exec.
+# (%q emits bash ANSI-C $'...' quoting, so the rewrite assumes a bash-compatible executor — Claude's is.)
+wrapped="flock -x $lockfile bash -c $(printf '%q' "$cmd")"
+
+# Rewrite the tool input. updatedInput must restate the full tool_input object.
+printf '%s' "$input" | jq --arg c "$wrapped" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "allow",
+    updatedInput: (.tool_input + { command: $c })
+  }
+}'

--- a/dotfiles/claude/.claude/settings.json
+++ b/dotfiles/claude/.claude/settings.json
@@ -1,0 +1,99 @@
+{
+  "permissions": {
+    "defaultMode": "auto"
+  },
+  "model": "opus[1m]",
+  "hooks": {
+    "ElicitationResult": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; mkdir -p \"/tmp/aoe-hooks/$AOE_INSTANCE_ID\" 2>/dev/null; printf running > \"/tmp/aoe-hooks/$AOE_INSTANCE_ID/status\" 2>/dev/null; exit 0'"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt|elicitation_dialog",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; mkdir -p \"/tmp/aoe-hooks/$AOE_INSTANCE_ID\" 2>/dev/null; printf waiting > \"/tmp/aoe-hooks/$AOE_INSTANCE_ID/status\" 2>/dev/null; exit 0'"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; mkdir -p \"/tmp/aoe-hooks/$AOE_INSTANCE_ID\" 2>/dev/null; printf running > \"/tmp/aoe-hooks/$AOE_INSTANCE_ID/status\" 2>/dev/null; exit 0'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/aoe-lock.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; command -v aoe >/dev/null 2>&1 || exit 0; aoe __extract-session-id 2>/dev/null; exit 0 # aoe-hooks'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; mkdir -p \"/tmp/aoe-hooks/$AOE_INSTANCE_ID\" 2>/dev/null; printf idle > \"/tmp/aoe-hooks/$AOE_INSTANCE_ID/status\" 2>/dev/null; exit 0'"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; command -v aoe >/dev/null 2>&1 || exit 0; aoe __extract-session-id 2>/dev/null; exit 0 # aoe-hooks'"
+          },
+          {
+            "type": "command",
+            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; mkdir -p \"/tmp/aoe-hooks/$AOE_INSTANCE_ID\" 2>/dev/null; printf running > \"/tmp/aoe-hooks/$AOE_INSTANCE_ID/status\" 2>/dev/null; exit 0'"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "sontek-skills@sontek-skills-local": true,
+    "gopls-lsp@claude-plugins-official": true
+  },
+  "extraKnownMarketplaces": {
+    "sontek-skills-local": {
+      "source": {
+        "source": "directory",
+        "path": "/Users/john/code/sontek/sontek-skills"
+      }
+    }
+  },
+  "alwaysThinkingEnabled": true,
+  "skipDangerousModePermissionPrompt": true,
+  "theme": "dark",
+  "skipAutoPermissionPrompt": true
+}

--- a/justfile
+++ b/justfile
@@ -69,6 +69,7 @@ install-system-apps:
   @just install-nix "easyrsa"
   @just install-nix "eza"
   @just install-nix "ffmpeg"
+  @just install-nix "flock"
   @just install-nix "fontconfig"
   @just install-nix "freetype"
   @just install-nix "fzf"


### PR DESCRIPTION
Running aoe in several worktrees at once let each session fire pytest -nauto independently, and two parallel runs would saturate CPU and RAM and stall the machine. This adds a Claude Code PreToolUse(Bash) hook that detects expensive test commands and rewrites them to run under an flock mutex, so only one test run executes at a time across every worktree on the host. flock holds the lock for the command's lifetime and the kernel releases it on exit or crash, so there is no stale-lock cleanup to manage.

Lanes are independent: a deploy lane is scaffolded alongside the test lane so a future deploy serializer drops in without reworking the mechanism. The hook is fail-open by design, passing the command through untouched whenever anything is missing or unexpected (no jq/flock, non-Bash tool, empty or already-wrapped command).

Also adds flock to the provisioning tool list so the hook's dependency is present. Verified end to end via a fresh headless session: a matching command runs under flock.