### PR TITLE
fix(dotfiles): stop forcing TERM, fall back to xterm-256color only when broken

### DIFF
--- a/dotfiles/tmux/.config/tmux/tmux.conf
+++ b/dotfiles/tmux/.config/tmux/tmux.conf
@@ -15,9 +15,4 @@ bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 
-# Advertise a full terminfo inside tmux and forward cursor-shape escapes (DECSCUSR)
-# so TUIs like the aoe/claude input box can position and style the caret. Without
-# the Ss/Se override the caret gets swallowed and you can't see where you're typing.
-set -g default-terminal "tmux-256color"
-set -ga terminal-overrides ',*:Ss=\E[%p1%d q:Se=\E[ q'
-set -as terminal-features ',xterm*:RGB'
+set -g default-terminal "xterm-256color"

--- a/dotfiles/zsh/.config/zsh/.zshrc
+++ b/dotfiles/zsh/.config/zsh/.zshrc
@@ -1,7 +1,8 @@
-# Upgrade a bare/downgraded TERM (e.g. the plain "xterm" colima ssh hands the VM)
-# to 256color, but leave richer values (xterm-kitty, tmux-256color, screen-*) alone
-# so we don't clobber the terminal's real capabilities or tmux's default-terminal.
-[[ -z "$TERM" || "$TERM" == "xterm" ]] && export TERM="xterm-256color"
+# Keep the terminal's real TERM (kitty, tmux, screen) when its terminfo entry
+# resolves; only fall back to a universally-present 256color entry when it
+# doesn't — so a bare/unknown TERM can't break `clear` and friends with
+# "unknown terminal type", without clobbering capable terminals.
+infocmp "$TERM" >/dev/null 2>&1 || export TERM="xterm-256color"
 export PS1="> "
 
 # Ensure core system paths are always present (GUI-launched shells

--- a/vm-bootstrap.sh
+++ b/vm-bootstrap.sh
@@ -52,9 +52,7 @@ else
   # extension ("cannot open shared object file: libfzf.so").
   log "apt: updating index + installing curl xz-utils just ripgrep zsh build-essential ..."
   sudo -E apt-get update
-  # ncurses-term ships the tmux-256color terminfo entry into /usr/share/terminfo
-  # so the apt tmux finds it (the cursor-shape fix in tmux.conf depends on it).
-  sudo -E apt-get -y install curl xz-utils just ripgrep zsh build-essential stow ncurses-term
+  sudo -E apt-get -y install curl xz-utils just ripgrep zsh build-essential
   if [ ! -e /nix ] && ! command -v nix >/dev/null 2>&1; then
     log "nix: installing Determinate Nix (this is the slow step) ..."
     curl --retry 3 --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
@@ -115,20 +113,6 @@ print("    sontek-skills@sontek-skills-local enabled -> " + skills)
 PY
 else
   log "claude: $SKILLS_DIR not mounted, skipping plugin registration"
-fi
-
-# Symlink our terminal dotfiles into the VM so tmux + zsh behave like the host —
-# notably a real TERM (the zsh rc upgrades colima's bare "xterm" to 256color) and
-# tmux cursor-shape passthrough, so TUI cursors (aoe/claude input box) render.
-# Scoped to the terminal packages: the `claude` package's settings are managed
-# above, and the mac-only packages (kitty/alacritty/colima) aren't useful here.
-HOMIES_DIR="$HOME/code/sontek/homies"
-if [ -d "$HOMIES_DIR/dotfiles" ] && command -v stow >/dev/null 2>&1; then
-  log "stow: symlinking tmux + zsh dotfiles into \$HOME ..."
-  ( cd "$HOMIES_DIR/dotfiles" && stow --restow --target="$HOME" tmux zsh ) \
-    || log "stow: skipped/failed (non-fatal)"
-else
-  log "stow: dotfiles not mounted or stow missing — skipping dotfile symlinks"
 fi
 
 log "done: just/ripgrep/curl + nix + claude ready; ~/code bind mounts in place"


### PR DESCRIPTION
## What

PR #48 (commit b262a28) changed the zsh rc to leave the terminal's real `TERM` untouched, only upgrading a bare `xterm`. That let values like `xterm-kitty` pass straight through to environments lacking that terminfo entry, breaking `clear` and other terminfo consumers with:

```
'xterm-kitty': unknown terminal type.
```

## Change

- **zsh rc**: instead of either force-setting `TERM=xterm` (the original, no 256 color) or passing rich values through blindly (PR #48, the breakage), keep the real `TERM` when its terminfo entry resolves and fall back to the universally-present `xterm-256color` only when `infocmp` can't find it. Capable terminals (kitty, tmux, screen) keep their `TERM`; broken/unknown ones get a safe default.
- **tmux.conf**: reverts the `tmux-256color` default-terminal + cursor-shape override back to `xterm-256color`.
- **vm-bootstrap.sh**: reverts the `stow` + `ncurses-term` install and dotfile symlinking.

## Why this default

Fully reverting would restore `export TERM="xterm"` — the most capability-starved terminfo (no 256 color). The `infocmp` guard avoids both the downgrade and the unknown-terminal-type breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)