### PR TITLE
feat(vm-bootstrap): symlink ~/screenshots to the host mount in-VM

### DIFF
--- a/vm-bootstrap.sh
+++ b/vm-bootstrap.sh
@@ -40,6 +40,19 @@ for d in /Users/*/code/*/; do
   fi
 done
 
+# Expose the read-only ~/screenshots host mount under the guest home too. It
+# lands at its literal host path (/Users/<you>/screenshots) — which is what a
+# dragged screenshot's path already points to — but the guest home differs
+# (/home/<you>.guest), so a bare `~/screenshots` wouldn't resolve. Symlink it so
+# the short path works inside the VM. A symlink (not a bind mount) is fine here:
+# we only ever read files by path, never cd into it as a session cwd.
+for s in /Users/*/screenshots; do
+  [ -d "$s" ] || continue
+  ln -sfn "$s" "$HOME/screenshots"
+  echo "    ~/screenshots -> $s (symlink)"
+  break
+done
+
 # One-time bootstrap: homies prerequisites (just + ripgrep, used by its justfile)
 # plus curl/xz-utils, then Determinate Nix. Sentinel-guarded so it runs once.
 if [ -f /var/lib/.homies-bootstrap-done ]; then


### PR DESCRIPTION
Symlink ~/screenshots under the guest home so the short path resolves inside dev VMs.

The screenshots mount added in #52 lands at its literal host path inside the VM, but the guest home is a different directory, so typing ~/screenshots in the VM didn't resolve. A dragged screenshot's absolute path already worked; this makes the convenient ~ form work too when pointing an in-VM agent at a screenshot.

It's a symlink rather than a bind mount because we only read files by path here, never cd into it as a session working directory.