### PR TITLE
feat: Dev-env polish: clickable links, gruvbox tmux theme, Playwright deps

### DIFF
--- a/dotfiles/tmux/.config/tmux/tmux.conf
+++ b/dotfiles/tmux/.config/tmux/tmux.conf
@@ -16,3 +16,10 @@ bind k select-pane -U
 bind l select-pane -R
 
 set -g default-terminal "xterm-256color"
+
+# Forward OSC 8 hyperlinks to the outer terminal (e.g. Claude Code's clickable
+# "PR #NNNN" footer link). tmux 3.4+ supports hyperlinks but only emits them
+# when the feature is attached to the OUTER terminal's TERM. kitty reports
+# TERM=xterm-kitty, so the pattern must match xterm* (not xterm-256color, which
+# is only what tmux presents *inside* the session).
+set -as terminal-features ",xterm*:hyperlinks"

--- a/dotfiles/tmux/.config/tmux/tmux.conf
+++ b/dotfiles/tmux/.config/tmux/tmux.conf
@@ -23,3 +23,42 @@ set -g default-terminal "xterm-256color"
 # TERM=xterm-kitty, so the pattern must match xterm* (not xterm-256color, which
 # is only what tmux presents *inside* the session).
 set -as terminal-features ",xterm*:hyperlinks"
+
+# True color, so theme colors render accurately in kitty/ghostty.
+set -as terminal-features ",xterm*:RGB"
+
+# ── Quality of life ──────────────────────────────────────────────────────────
+set -g base-index 1             # number windows from 1
+setw -g pane-base-index 1       # number panes from 1
+set -g renumber-windows on      # close a window -> renumber so there are no gaps
+set -sg escape-time 0           # no delay after ESC (otherwise laggy in vim)
+set -g focus-events on          # let apps (vim, etc.) react to pane focus changes
+set -g status-interval 5        # redraw status line (clock) every 5s
+
+# ── Theme: gruvbox dark ──────────────────────────────────────────────────────
+# bg #282828  bg1 #3c3836  gray #928374  fg4 #a89984  fg #ebdbb2
+# orange #fe8019  yellow #d79921
+set -g status-style "bg=#282828,fg=#a89984"
+set -g status-left-length 40
+set -g status-right-length 80
+set -g status-justify left
+
+# Left: session name as an orange block.
+set -g status-left "#[fg=#282828,bg=#fe8019,bold] #S #[fg=#fe8019,bg=#282828,nobold]  "
+
+# Windows: inactive dim gray; active orange/bold on a slightly raised bg.
+set -g window-status-format "#[fg=#928374] #I #W #[default]"
+set -g window-status-current-format "#[fg=#fe8019,bg=#3c3836,bold] #I #W #[default]"
+set -g window-status-separator ""
+
+# Right: current pane's directory + clock.
+set -g status-right "#[fg=#928374]#{b:pane_current_path}  #[fg=#ebdbb2,bold]%H:%M "
+
+# Pane borders: dim inactive, orange active.
+set -g pane-border-style "fg=#3c3836"
+set -g pane-active-border-style "fg=#fe8019"
+
+# Command prompt / messages and copy-mode selection.
+set -g message-style "bg=#fe8019,fg=#282828,bold"
+set -g message-command-style "bg=#3c3836,fg=#ebdbb2"
+set -g mode-style "bg=#d79921,fg=#282828"

--- a/dotfiles/zsh/.zshenv
+++ b/dotfiles/zsh/.zshenv
@@ -10,3 +10,13 @@ then
 fi
 
 ulimit -n 4096
+
+# Force OSC 8 hyperlink output for CLIs that probe terminal support (Claude Code's
+# clickable "PR #NNNN" footer link, etc.). Needed inside SSH'd VMs (e.g. colima),
+# where TERM degrades to xterm-256color and kitty's terminfo is absent, so tools
+# can't detect that the real terminal at the end of the pipe (kitty) supports
+# hyperlinks. SSH passes the escapes through untouched. Interactive-only to avoid
+# leaking escapes into redirected output of non-interactive scripts.
+if [[ -t 1 ]]; then
+    export FORCE_HYPERLINK=1
+fi

--- a/justfile
+++ b/justfile
@@ -218,22 +218,34 @@ vm-bootstrap name:
 vm-down name:
   colima stop {{name}}
 
-# Shell into a VM. When invoked from kitty, use kitty's `ssh` kitten: it copies
-# kitty's terminfo to the VM and sets TERM=xterm-kitty, so OSC 8 hyperlinks (e.g.
-# Claude Code's clickable "PR #NNNN" link), truecolor, and other TUI features
-# survive the SSH hop -- including inside a remote tmux. colima already publishes
-# an ssh_config (Host colima-<name>), Include'd from ~/.ssh/config, so the kitten
-# can reach the VM directly. Falls back to plain `colima ssh` elsewhere.
+# Shell into a VM with the local terminal's identity carried over the SSH hop,
+# so OSC 8 hyperlinks (e.g. Claude Code's clickable "PR #NNNN" link), truecolor,
+# and other TUI features work -- including inside a remote tmux. colima publishes
+# an ssh_config (Host colima-<name>), Include'd from ~/.ssh/config, so we can ssh
+# the VM directly. Handles kitty and ghostty; anything else (and inside tmux,
+# where TERM is rewritten and these handshakes break) falls back to plain colima
+# ssh, where hyperlinks still ride the FORCE_HYPERLINK + tmux xterm*:hyperlinks
+# fallback.
 vm-ssh name:
   #!/usr/bin/env bash
   set -euo pipefail
-  # Use kitty's ssh kitten only when talking directly to kitty. TERM=xterm-kitty
-  # means a real kitty window; inside tmux, tmux rewrites TERM (e.g. to
-  # xterm-256color), so this also excludes the nested-tmux case where the
-  # kitten's terminal-detection handshake misbehaves. Otherwise: plain colima ssh.
-  if [[ "${TERM:-}" == *kitty* ]] && command -v kitten >/dev/null 2>&1; then
-    exec kitten ssh "colima-{{name}}"
-  fi
+  host="colima-{{name}}"
+  case "${TERM:-}" in
+    *kitty*)
+      # kitty: the ssh kitten copies terminfo and sets TERM=xterm-kitty itself
+      # (and Claude detects kitty straight from TERM containing "kitty").
+      if command -v kitten >/dev/null 2>&1; then exec kitten ssh "$host"; fi
+      ;;
+    xterm-ghostty)
+      # ghostty has no kitten. Push its terminfo to the VM if missing, then force
+      # TERM on the remote login shell -- lima's sshd ignores a forwarded/SetEnv
+      # TERM, so it only sticks when set in the remote command. Also set
+      # TERM_PROGRAM, which is how Claude detects ghostty (TERM alone won't).
+      ssh "$host" -- 'infocmp xterm-ghostty >/dev/null 2>&1' \
+        || infocmp -x xterm-ghostty | ssh "$host" -- 'tic -x -' >/dev/null 2>&1 || true
+      exec ssh -t "$host" -- 'TERM=xterm-ghostty TERM_PROGRAM=ghostty exec "$SHELL" -l'
+      ;;
+  esac
   exec colima ssh -p {{name}}
 
 # Show a VM's status and address

--- a/justfile
+++ b/justfile
@@ -218,9 +218,23 @@ vm-bootstrap name:
 vm-down name:
   colima stop {{name}}
 
-# Shell into a VM
+# Shell into a VM. When invoked from kitty, use kitty's `ssh` kitten: it copies
+# kitty's terminfo to the VM and sets TERM=xterm-kitty, so OSC 8 hyperlinks (e.g.
+# Claude Code's clickable "PR #NNNN" link), truecolor, and other TUI features
+# survive the SSH hop -- including inside a remote tmux. colima already publishes
+# an ssh_config (Host colima-<name>), Include'd from ~/.ssh/config, so the kitten
+# can reach the VM directly. Falls back to plain `colima ssh` elsewhere.
 vm-ssh name:
-  colima ssh -p {{name}}
+  #!/usr/bin/env bash
+  set -euo pipefail
+  # Use kitty's ssh kitten only when talking directly to kitty. TERM=xterm-kitty
+  # means a real kitty window; inside tmux, tmux rewrites TERM (e.g. to
+  # xterm-256color), so this also excludes the nested-tmux case where the
+  # kitten's terminal-detection handshake misbehaves. Otherwise: plain colima ssh.
+  if [[ "${TERM:-}" == *kitty* ]] && command -v kitten >/dev/null 2>&1; then
+    exec kitten ssh "colima-{{name}}"
+  fi
+  exec colima ssh -p {{name}}
 
 # Show a VM's status and address
 vm-status name:

--- a/vm-bootstrap.sh
+++ b/vm-bootstrap.sh
@@ -66,6 +66,22 @@ else
   log "apt: updating index + installing curl xz-utils just ripgrep zsh build-essential ..."
   sudo -E apt-get update
   sudo -E apt-get -y install curl xz-utils just ripgrep zsh build-essential
+  # Headless-Chromium system libraries for Playwright. Projects that render with
+  # a headless browser (docs sites using mkdocs-to-pdf / mermaid, screenshot
+  # tooling, etc.) ultimately run `playwright install chromium`, and the
+  # downloaded Chromium needs these .so's to launch. Installing them once here
+  # means that later install works without --with-deps (which shells out to sudo
+  # at runtime). The Chromium binary itself is downloaded per-project into the
+  # shared ~/.cache/ms-playwright, so it's cached machine-wide after first use.
+  # This is Playwright's Chromium dep set for Ubuntu 24.04 (noble); regenerate
+  # with `playwright install-deps --dry-run chromium` if it drifts.
+  log "apt: installing Playwright headless-Chromium system libraries ..."
+  sudo -E apt-get -y install --no-install-recommends \
+    libnss3 libnspr4 libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 \
+    libxkbcommon0 libatspi2.0-0t64 libxcomposite1 libxdamage1 libxfixes3 \
+    libxrandr2 libgbm1 libasound2t64 libpango-1.0-0 libcairo2 libdbus-1-3 \
+    libdrm2 libxcb1 libx11-6 libxext6 libglib2.0-0t64 \
+    fonts-liberation fonts-noto-color-emoji xvfb
   if [ ! -e /nix ] && ! command -v nix >/dev/null 2>&1; then
     log "nix: installing Determinate Nix (this is the slow step) ..."
     curl --retry 3 --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \


### PR DESCRIPTION
A few homies dev-env improvements from one session spent getting Claude Code's
clickable links and the tmux setup right.

Clickable hyperlinks: Claude Code's footer "PR #NNNN" link is an OSC 8
hyperlink, and it was being dropped at the terminal-capability layer, never in
transit. tmux only forwards OSC 8 when the feature is advertised against the
outer terminal (kitty and ghostty both match xterm*). Over SSH to a colima VM,
plain colima ssh hands the VM a generic TERM with no terminfo, so nothing
downstream knows kitty or ghostty is at the far end; vm-ssh now carries the
terminal identity over the hop (kitty's ssh kitten, or pushing ghostty's
terminfo and forcing TERM/TERM_PROGRAM), with a forced-hyperlink fallback for
the plain path and inside tmux.

tmux theme: the status bar was the stock default. This swaps in a gruvbox-dark
theme and the usual ergonomic defaults (1-based numbering, no ESC delay, focus
events, truecolor).

Playwright VM deps: preinstall the system libraries headless Chromium needs, so
a later `playwright install chromium` works without pulling deps through sudo at
runtime. Unrelated to the rest, bundled in at request.